### PR TITLE
Updates for Varnish 3.0 compatibility

### DIFF
--- a/wordpress.vcl
+++ b/wordpress.vcl
@@ -12,8 +12,7 @@ sub vcl_recv {
     if(!client.ip ~ purge) {
       error 405 "Not allowed.";
     }
-
-    purge("req.url ~ ^" req.url "$ && req.http.host == "req.http.host);
+    return(lookup);
   }
 
   if (req.request != "GET" &&
@@ -38,9 +37,23 @@ sub vcl_recv {
   return (lookup);
 }
 
+sub vcl_hit {
+  if (req.request == "PURGE") {
+    purge;
+    error 200 "Purged.";
+  }
+}
+
+sub vcl_miss {
+  if (req.request == "PURGE") {
+    purge;
+    error 200 "Purged.";
+  }
+}
+
 sub vcl_fetch {
   if (req.url ~ "wp-(login|admin)" || req.url ~ "preview=true") {
-    return (pass);
+    return (hit_for_pass);
   }
 
   set beresp.ttl = 24h;


### PR DESCRIPTION
Updated purge request compatibility with V3.0 syntax
Updated vcl_fetch pass to hit_for_pass

https://www.varnish-cache.org/docs/3.0/installation/upgrade.html#pass-in-vcl-fetch-renamed-to-hit-for-pass
