### PR TITLE
Fix deprecated warning when creating new WPVarnish

### DIFF
--- a/wp-varnish.php
+++ b/wp-varnish.php
@@ -381,6 +381,6 @@ class WPVarnish {
   }
 }
 
-$wpvarnish = & new WPVarnish();
+$wpvarnish = new WPVarnish();
 
 ?>


### PR DESCRIPTION
When turning on all errors, php shows a deprecated warning. It looks like the & is not needed when creating a new object. Removing the & seems to work fine.

```
Deprecated: Assigning the return value of new by reference is deprecated in /home/buddy/code/wordpress/docroot/wp-content/plugins/wordpress-varnish/wp-varnish.php on line 292
```

To turn on all errors in php, I just added this to my functions.php file in my theme:

``` php
error_reporting(E_ALL);
ini_set('display_errors', 1); 
```
