### PR TITLE
I suck at pull requests

### DIFF
--- a/wp-varnish.php
+++ b/wp-varnish.php
@@ -258,12 +258,15 @@ class WPVarnish {
     <?php
           // Can't be edited - already defined in wp-config.php
           global $varnish_servers;
+          global $varnish_version;
           if (is_array($varnish_servers)) {
              echo "<p>" . __("These values can't be edited since there's a global configuration located in <em>wp-config.php</em>. If you want to change these settings, please update the file or contact the administrator.",'wp-varnish') . "</p>\n";
              // Also, if defined, show the varnish servers configured (VARNISH_SHOWCFG)
              if (defined('VARNISH_SHOWCFG')) {
                 echo "<h3>" . __("Current configuration:",'wp-varnish') . "</h3>\n";
                 echo "<ul>";
+                if ( isset($varnish_version) && $varnish_version )
+                   echo "<li>" . __("Version: ",'wp-varnish') . $varnish_version . "</li>";
                 foreach ($varnish_servers as $server) {
                    list ($host, $port, $secret) = explode(':', $server);
                    echo "<li>" . __("Server: ",'wp-varnish') . $host . "<br/>" . __("Port: ",'wp-varnish') . $port . "</li>";


### PR DESCRIPTION
Lumped a 4 in 1 because I don't know wtf I'm doing.
1. Module failed to activate with a fatal error
   Error was:
   PHP message: PHP Fatal error: Call-time pass-by-reference has been removed in /var/www/mypolicedev.com/html/wp-content/plugins/wp-varnish/wp-varnish.php on line 365
2. Missing argument 2/3 for WPVarnish::WPVarnishPurgeCommonObjectsStatus()
   Added missing add_action() parameter as defined in the WordPress documentation to allow passing of second and third arguments:
   http://codex.wordpress.org/Function_Reference/add_action
3. and 4. Added support for global $varnish_version setting.
   Usage: 
   After $varnish_servers = array(...); add:
   global $varnish_version;
   $varnish_version = 3;
