### PR TITLE
allow wp-config.php specified varnish_servers to define secret.

### DIFF
--- a/wp-varnish.php
+++ b/wp-varnish.php
@@ -352,9 +352,10 @@ class WPVarnish {
 
     if (is_array($varnish_servers)) {
        foreach ($varnish_servers as $server) {
-          list ($host, $port) = explode(':', $server);
+          list ($host, $port, $secret) = explode(':', $server);
           $wpv_purgeaddr[] = $host;
           $wpv_purgeport[] = $port;
+          $wpv_secret[] = $secret;
        }
     } else {
        $wpv_purgeaddr = get_option($this->wpv_addr_optname);


### PR DESCRIPTION
modify WPVarnishPurgeObject to explode $varnish_servers into secret as
well as host and port. That way static $varnish_servers can use the
admin port as well.

This 3-way exploding is actually already done in WPVarnishAdmin. 
