### PR TITLE
Check for the 'manage_options' capability instead of the 'administrator'...

### DIFF
--- a/wp-varnish.php
+++ b/wp-varnish.php
@@ -239,7 +239,7 @@ function WPVarnishPostID() {
   // WpVarnishAdmin - Draw the administration interface.
   function WPVarnishAdmin() {
     if ($_SERVER["REQUEST_METHOD"] == "GET") {
-       if (current_user_can('administrator')) {
+       if (current_user_can('manage_options')) {
 
           $nonce = $_REQUEST['_wpnonce'];
 
@@ -254,7 +254,7 @@ function WPVarnishPostID() {
           }
        }
     }elseif ($_SERVER["REQUEST_METHOD"] == "POST") {
-       if (current_user_can('administrator')) {
+       if (current_user_can('manage_options')) {
           if (isset($_POST['wpvarnish_admin'])) {
              cleanSubmittedData('wpvarnish_port', '/[^0-9]/');
              cleanSubmittedData('wpvarnish_addr', '/[^0-9.]/');


### PR DESCRIPTION
... role

Although passing a role in the 'current_user_can' function seems to work, the best practice is to pass a capability, like 'manage_options' in order to check if the user is admin.

Please read the following pages:
- http://codex.wordpress.org/Function_Reference/current_user_can#Notes
- http://core.trac.wordpress.org/ticket/22624
