### PR TITLE
Fix #72 replaced role 1 with 'publish_posts' cabìpability

### DIFF
--- a/wp-varnish.php
+++ b/wp-varnish.php
@@ -368,7 +368,7 @@ function WPVarnishPostID() {
 
   function WPVarnishAdminMenu() {
     if (!defined('VARNISH_HIDE_ADMINMENU')) {
-      add_options_page(__('WP-Varnish Configuration','wp-varnish'), 'WP-Varnish', 1, 'WPVarnish', array($this, 'WPVarnishAdmin'));
+      add_options_page(__('WP-Varnish Configuration','wp-varnish'), 'WP-Varnish', 'publish_posts', 'WPVarnish', array($this, 'WPVarnishAdmin'));
     }
   }
 


### PR DESCRIPTION
I assumed that 'publish_post' is somehow related to invalidating cache.