### PR TITLE
Fixed typographical error, changed adminstration to administration in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,7 +74,7 @@ surfer's IP rather than the server's IP.
 Screenshots
 -----------
 
-1. Screenshot of the adminstration interface.
+1. Screenshot of the administration interface.
 
 Changelog
 ---------

--- a/readme.txt
+++ b/readme.txt
@@ -70,7 +70,7 @@ surfer's IP rather than the server's IP.
 
 == Screenshots ==
 
-1. Screenshot of the adminstration interface.
+1. Screenshot of the administration interface.
 
 == Changelog ==
 


### PR DESCRIPTION
@pkhamre, I've corrected a typographical error in the documentation of the [wp-varnish](https://github.com/pkhamre/wp-varnish) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.